### PR TITLE
Add a link from the framesplit to the build screen

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4,6 +4,38 @@ html { box-sizing: border-box; } *, *:before, *:after { box-sizing: inherit; }
 
 html, body {
   height: 100%;
+  font: medium/1.4 "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.build-link a {
+  display: block;
+  width: 100%;
+  padding: 1em;
+
+  font-size: 2em;
+}
+
+.js-enabled .build-link {
+  position: absolute;
+  top: 0;
+  width: 100%;
+
+  margin-top: -150px;
+  padding-bottom: 100px;
+
+  text-align: center;
+
+  transition: margin-top ease .75s;
+}
+
+.js-enabled .build-link a {
+  background: #222;
+  color: #fff;
+  border-bottom: 4px solid #000;
+}
+
+.js-enabled .build-link:hover {
+  margin-top: 0px;
 }
 
 .container,

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,6 +5,12 @@
 
 	FrameView.prototype.render = function(layout, urls, title) {
 
+		if (!urls) {
+			return;
+		}
+
+		this.$root.parents('body').addClass('js-enabled');
+
 		this.$root.parents('html').find('title').text(title || 'Frame Splits')
 
 		this.$root.empty()
@@ -17,6 +23,9 @@
 				return $('<iframe>').attr('src', url).addClass('item item-' + (index+1))[0];
 			})
 		);
+
+		var editLink = this.$root.parent().find('.build-link a');
+		editLink.attr('href', editLink.attr('href') + document.location.search);
 	};
 
 	root.FrameView = FrameView;

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 <body>
   <div class="container">
 
+    <div class="build-link"><a href="build.html">Edit</a></div>
     <div class="layout layout-frames">
     </div>
 


### PR DESCRIPTION
Hidden, but magically appearing on hover (over a transparent area)
so it doesn't interfere visually at all, but is relatively easy
to get to.

Better than having to edit the URL.

If it's loaded without URLs, then the edit link is shown
unconditionally, which is actually an improvement over the
previous (completely) blank default.
