### PR TITLE
Add 75/25 2col layout.

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -62,6 +62,9 @@ html, body {
 
 .layout-2col .item { width: 50%; }
 
+.layout-2col-75-25 .item:first-child { width: 75%; }
+.layout-2col-75-25 .item { width: 25%; }
+
 .layout-3row .item { height: 33.3%; }
 
 .layout-3col .item { width: 33.3%; }

--- a/build.html
+++ b/build.html
@@ -34,6 +34,13 @@
         </li>
 
         <li>
+          <label for="layout-2col-75-25">
+            <input type="radio" id="layout-2col-75-25" name="layout" value="2col-75-25">
+            <span>2col-75-25</span>
+          </label>
+        </li>
+
+        <li>
           <label for="layout-3row">
             <input type="radio" id="layout-3row" name="layout" value="3row">
             <span>3row</span>


### PR DESCRIPTION
We've often encountered a need to display a wider screen alongside a
narrower column. This adds a layout to support this.

This PR also includes a fix for serving assets from the vendor folder since Github have upgraded Jekyll. See the commit message for more details.